### PR TITLE
[fix]: render full HTML page for direct navigation to my-classes

### DIFF
--- a/code/src/controllers/class.controller.js
+++ b/code/src/controllers/class.controller.js
@@ -67,6 +67,7 @@ export const getUserClasses = asyncHandler(async (req, res) => {
 /**
  * Render class list page for HTMX
  * Uses authenticated user from JWT cookie
+ * Supports both HTMX requests (HTML fragment) and direct navigation (full page)
  */
 export const renderUserClasses = asyncHandler(async (req, res) => {
   // Priority: JWT auth (production), fallback to query param (testing)
@@ -78,9 +79,19 @@ export const renderUserClasses = asyncHandler(async (req, res) => {
   }
 
   const classes = await classService.getClassesByUserId(userId);
-  const html = renderClassListHTML(classes);
+  const content = renderClassListHTML(classes);
 
-  res.send(html);
+  // Check if this is an HTMX request or direct browser navigation
+  const isHtmxRequest = req.headers['hx-request'];
+
+  if (isHtmxRequest) {
+    // HTMX request: return HTML fragment for dynamic content swap
+    res.send(content);
+  } else {
+    // Direct navigation: return full HTML page with styles and layout
+    const fullPage = renderFullPage(content, 'My Classes');
+    res.send(fullPage);
+  }
 });
 
 /**
@@ -204,5 +215,71 @@ function renderAuthRequiredHTML() {
         </p>
       </div>
     </section>
+  `;
+}
+
+/**
+ * Helper function to render full HTML page for direct navigation
+ * Wraps content in complete HTML structure with styles and layout
+ */
+function renderFullPage(content, title = 'My Classes') {
+  return `
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${escapeHtml(title)} - Monkey School</title>
+    
+    <!-- HTMX Library -->
+    <script src="https://unpkg.com/htmx.org@1.9.8" 
+            integrity="sha384-rgjA7mptc2ETQqXoYC3/zJvkU7K/aP44Y+z7xQuJiVnB/422P/Ak+F/AqFR7E4Wr" 
+            crossorigin="anonymous"></script>
+    
+    <!-- Font Awesome Icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" 
+          integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" 
+          crossorigin="anonymous" 
+          referrerpolicy="no-referrer" />
+    
+    <!-- Application Styles -->
+    <link rel="stylesheet" href="/css/navbar.css">
+    <link rel="stylesheet" href="/css/main.css">
+    
+    <!-- Application Scripts -->
+    <script type="module" src="/js/app.js" defer></script>
+</head>
+<body>
+    <!-- Skip to main content for screen readers -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    
+    <!-- Navigation Bar (Left Fixed) -->
+    <div id="navbar" class="navbar"></div>
+    
+    <!-- Sub-Menu (Collapsible Side Menu) -->
+    <div id="submenu" class="submenu"></div>
+    
+    <!-- Header (Top Bar) -->
+    <header id="header" class="header" role="banner">
+        <div class="container">
+            <div class="header__content">
+                <div class="header__left"></div>
+                <div class="header__right"></div>
+            </div>
+            <h1 class="header__title">
+                <a href="/" class="header__link">Student Management System</a>
+            </h1>
+        </div>
+    </header>
+
+    <main id="main-content" class="main" role="main" tabindex="-1">
+        <div class="container">
+            ${content}
+        </div>
+    </main>
+
+    <footer id="footer" class="footer" role="contentinfo"></footer>
+</body>
+</html>
   `;
 }


### PR DESCRIPTION
- Add detection for HTMX requests vs direct browser navigation
- Return HTML fragment for HTMX (existing behavior)
- Return complete HTML page for direct URL access
- Add renderFullPage() helper function with full layout structure
- Fixes issue where direct navigation showed unstyled content

<img width="1892" height="1005" alt="integrated" src="https://github.com/user-attachments/assets/4d1d327e-7d48-4914-8409-7cafe5b58f80" />


Closes #7 