### PR TITLE
[Feat]: profile pic update

### DIFF
--- a/code/src/utils/components/profile-page.js
+++ b/code/src/utils/components/profile-page.js
@@ -105,11 +105,12 @@ export function createUserProfile(user, { mode = "view" } = {}) {
             }
         </ul>`;
 
-  const avatarSrc = user.photoUrl && !user.photoUrl.includes("default") 
-    ? user.photoUrl 
-    : `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=random&size=120`;
+  const avatarSrc =
+    user.photoUrl && !user.photoUrl.includes("default")
+      ? user.photoUrl
+      : `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=random&size=120`;
 
-    const header = `
+  const header = `
     <header class="profile-hero">
     <figure class="profile-hero__avatar">
         <img 
@@ -127,13 +128,14 @@ export function createUserProfile(user, { mode = "view" } = {}) {
         </address>
     </div>
     <nav class="profile-hero__actions" aria-label="Profile actions">
-        ${isEdit
-        ? `<button type="submit" form="profile-form-${id}" class="btn btn--primary profile-hero__save">Save</button>
+        ${
+          isEdit
+            ? `<button type="submit" form="profile-form-${id}" class="btn btn--primary profile-hero__save">Save</button>
             <button type="button" class="btn btn--secondary"
                     hx-get="/users/profile"
                     hx-target="#main-content"
                     hx-push-url="true">Cancel</button>`
-        : `<a href="/users/profile?mode=edit"
+            : `<a href="/users/profile?mode=edit"
             hx-get="/users/profile?mode=edit"
             hx-target="#main-content"
             hx-push-url="true"
@@ -141,7 +143,6 @@ export function createUserProfile(user, { mode = "view" } = {}) {
         }
     </nav>
     </header>`;
-
 
   const containerOpen = `<section class="profile-content-container${isEdit ? " profile-content-container--edit" : " profile-content-container--view"}">`;
   const containerClose = `</section>`;


### PR DESCRIPTION
PR Summary:

Extract and save Google picture URL during OAuth login:

- auth.controller.js already fetches the google profile image url and auth.service.js stores it


Add photo_url field to user model if not present:

- the user.prisma scheme already has a field for photoUrl and the create/update logic writes to that field

Display user avatar on profile page (and optionally navbar):

- in /utils/components/profile-page.js, updated createUserProfile() to display google profile photo in the profile page component
    - if the photo fails to load (i.e. broken URL), then display initials

- using API for user initials as fallback: 

https://ui-avatars.com/api/name=${encodeURIComponent(user.name)}&background=random&size=120](https://ui-avatars.com/api/name=$%7BencodeURIComponent(user.name)%7D&background=random&size=120)

- did not implement replacing the default avatar in the header with the google photo in this PR

<img width="1410" height="664" alt="image" src="https://github.com/user-attachments/assets/971a4000-766b-4fe2-ad54-ba75277a4733" />

<img width="1413" height="663" alt="image" src="https://github.com/user-attachments/assets/cca0b481-11ea-4844-9932-bb17aa6e9d6d" />

Closes #33  